### PR TITLE
feat: extract hardcoded config to config.yaml

### DIFF
--- a/agent/loop.py
+++ b/agent/loop.py
@@ -16,19 +16,63 @@ from typing import Any, Awaitable, Callable
 import logging
 import sys
 
+import yaml
+
 logger = logging.getLogger(__name__)
+
+# Default config path relative to this file's directory
+_DEFAULT_CONFIG_PATH = Path(__file__).parent.parent / "config.yaml"
+
+# Sentinel for unset fields
+_UNSET = object()
+
+
+def _load_config_dict() -> dict[str, Any]:
+    """Load config from config.yaml if it exists."""
+    if _DEFAULT_CONFIG_PATH.exists():
+        try:
+            with open(_DEFAULT_CONFIG_PATH, "r") as f:
+                data = yaml.safe_load(f)
+                if data and "agent" in data:
+                    return data["agent"]
+        except Exception as exc:
+            logger.warning("Failed to load config.yaml: %s", exc)
+    return {}
+
+
+# Load config once at module level
+_yaml_config: dict[str, Any] = _load_config_dict()
 
 
 @dataclass
 class LoopConfig:
-    """Configuration for the agent loop."""
+    """Configuration for the agent loop.
 
-    model: str = "claude-sonnet-4-20250514"
-    max_iterations: int = 10
-    max_context_tokens: int = 100000
-    temperature: float = 0.7
-    timezone: str = "Asia/Shanghai"
-    workspace_path: str | Path = "."
+    Loads defaults from config.yaml in the project root.
+    Override individual fields to override config values.
+    """
+
+    model: str = _UNSET  # type: ignore[assignment]
+    max_iterations: int = _UNSET  # type: ignore[assignment]
+    max_context_tokens: int = _UNSET  # type: ignore[assignment]
+    temperature: float = _UNSET  # type: ignore[assignment]
+    timezone: str = _UNSET  # type: ignore[assignment]
+    workspace_path: str | Path = _UNSET  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        defaults = _yaml_config
+        if self.model is _UNSET:
+            object.__setattr__(self, "model", defaults.get("model", "claude-sonnet-4-20250514"))
+        if self.max_iterations is _UNSET:
+            object.__setattr__(self, "max_iterations", defaults.get("max_iterations", 10))
+        if self.max_context_tokens is _UNSET:
+            object.__setattr__(self, "max_context_tokens", defaults.get("max_context_tokens", 100000))
+        if self.temperature is _UNSET:
+            object.__setattr__(self, "temperature", defaults.get("temperature", 0.7))
+        if self.timezone is _UNSET:
+            object.__setattr__(self, "timezone", defaults.get("timezone", "Asia/Shanghai"))
+        if self.workspace_path is _UNSET:
+            object.__setattr__(self, "workspace_path", defaults.get("workspace_path", "."))
 
 
 @dataclass

--- a/agent/memory.py
+++ b/agent/memory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import time
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,7 @@
+agent:
+  model: "claude-sonnet-4-20250514"
+  max_iterations: 10
+  max_context_tokens: 100000
+  temperature: 0.7
+  timezone: "Asia/Shanghai"
+  workspace_path: "."

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests package."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,144 @@
+"""Tests for LoopConfig and config.yaml loading."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agent.loop import LoopConfig, _DEFAULT_CONFIG_PATH, _load_config_dict
+
+
+class TestLoadConfigDict:
+    """Tests for _load_config_dict function."""
+
+    def test_load_config_returns_dict(self) -> None:
+        """Test that _load_config_dict returns a dict."""
+        result = _load_config_dict()
+        assert isinstance(result, dict)
+
+    def test_load_config_contains_agent_section(self) -> None:
+        """Test that loaded config contains agent section."""
+        result = _load_config_dict()
+        # Should have agent-level keys
+        expected_keys = ["model", "max_iterations", "max_context_tokens", "temperature", "timezone", "workspace_path"]
+        for key in expected_keys:
+            assert key in result, f"Missing key: {key}"
+
+
+class TestLoopConfigDefaults:
+    """Tests for LoopConfig default values."""
+
+    def test_config_loads_defaults(self) -> None:
+        """Test that LoopConfig() loads defaults from config.yaml."""
+        config = LoopConfig()
+        assert config.model == "claude-sonnet-4-20250514"
+        assert config.max_iterations == 10
+        assert config.max_context_tokens == 100000
+        assert config.temperature == 0.7
+        assert config.timezone == "Asia/Shanghai"
+        assert config.workspace_path == "."
+
+    def test_config_override_values(self) -> None:
+        """Test that explicit values override defaults."""
+        config = LoopConfig(
+            model="gpt-4",
+            max_iterations=5,
+            max_context_tokens=50000,
+            temperature=0.5,
+            timezone="UTC",
+            workspace_path="/tmp",
+        )
+        assert config.model == "gpt-4"
+        assert config.max_iterations == 5
+        assert config.max_context_tokens == 50000
+        assert config.temperature == 0.5
+        assert config.timezone == "UTC"
+        assert config.workspace_path == "/tmp"
+
+
+class TestLoopConfigPartialOverride:
+    """Tests for partial override of config values."""
+
+    def test_partial_override_only_overrides_specified(self) -> None:
+        """Test that only specified fields are overridden."""
+        config = LoopConfig(model="custom-model")
+        # model should be overridden
+        assert config.model == "custom-model"
+        # others should use defaults
+        assert config.max_iterations == 10
+        assert config.max_context_tokens == 100000
+        assert config.temperature == 0.7
+        assert config.timezone == "Asia/Shanghai"
+        assert config.workspace_path == "."
+
+    def test_partial_override_multiple_fields(self) -> None:
+        """Test partial override with multiple fields."""
+        config = LoopConfig(max_iterations=20, temperature=1.0)
+        assert config.max_iterations == 20
+        assert config.temperature == 1.0
+        assert config.model == "claude-sonnet-4-20250514"
+        assert config.timezone == "Asia/Shanghai"
+
+
+class TestConfigYamlExists:
+    """Tests for config.yaml file presence."""
+
+    def test_config_yaml_exists(self) -> None:
+        """Test that config.yaml exists at expected path."""
+        assert _DEFAULT_CONFIG_PATH.exists(), f"config.yaml not found at {_DEFAULT_CONFIG_PATH}"
+
+    def test_config_yaml_valid_yaml(self) -> None:
+        """Test that config.yaml is valid YAML."""
+        with open(_DEFAULT_CONFIG_PATH, "r") as f:
+            data = yaml.safe_load(f)
+        assert data is not None
+        assert "agent" in data
+
+    def test_config_yaml_has_required_keys(self) -> None:
+        """Test that config.yaml has all required agent keys."""
+        with open(_DEFAULT_CONFIG_PATH, "r") as f:
+            data = yaml.safe_load(f)
+        agent_config = data["agent"]
+        required_keys = ["model", "max_iterations", "max_context_tokens", "temperature", "timezone", "workspace_path"]
+        for key in required_keys:
+            assert key in agent_config, f"Missing required key in config.yaml: {key}"
+
+
+class TestConfigYamlValues:
+    """Tests for config.yaml values."""
+
+    def test_model_is_string(self) -> None:
+        """Test that model is a string."""
+        config = LoopConfig()
+        assert isinstance(config.model, str)
+
+    def test_max_iterations_is_positive_int(self) -> None:
+        """Test that max_iterations is a positive integer."""
+        config = LoopConfig()
+        assert isinstance(config.max_iterations, int)
+        assert config.max_iterations > 0
+
+    def test_max_context_tokens_is_positive_int(self) -> None:
+        """Test that max_context_tokens is a positive integer."""
+        config = LoopConfig()
+        assert isinstance(config.max_context_tokens, int)
+        assert config.max_context_tokens > 0
+
+    def test_temperature_is_valid_range(self) -> None:
+        """Test that temperature is in valid range."""
+        config = LoopConfig()
+        assert isinstance(config.temperature, (int, float))
+        assert 0.0 <= config.temperature <= 2.0
+
+    def test_timezone_is_string(self) -> None:
+        """Test that timezone is a string."""
+        config = LoopConfig()
+        assert isinstance(config.timezone, str)
+
+    def test_workspace_path_is_string_or_path(self) -> None:
+        """Test that workspace_path is a string or Path."""
+        config = LoopConfig()
+        assert isinstance(config.workspace_path, (str, Path))


### PR DESCRIPTION
Extract LoopConfig defaults from agent/loop.py to config.yaml

- Add config.yaml with agent settings
- Modify LoopConfig to load from yaml with fallback defaults
- Fix missing dataclasses import in agent/memory.py
- Add tests/test_config.py